### PR TITLE
Fix guacd hostname

### DIFF
--- a/charts/guacamole/templates/secret.yaml
+++ b/charts/guacamole/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "guacamole.labels" . | indent 4 }}
 type: Opaque
 data:
-  GUACD_HOSTNAME: {{ printf "%s-%s" (include "guacamole.name" .) "guacd" | b64enc | quote }}
+  GUACD_HOSTNAME: {{ include "guacamole.fullname" . }}-guacd
   GUACD_PORT: {{ "4822" | b64enc | quote }}
   POSTGRES_HOSTNAME: {{ .Values.postgres.hostname | b64enc | quote }}
   POSTGRES_PORT: {{ .Values.postgres.port | b64enc | quote }}


### PR DESCRIPTION
The commit fixes env variable for guacd service inside the secret.

Depending on usage, Flux or ArgoCD may use the same release name as the chart name and it is working correctly, but when you use any custom release name or have no ability to specify release name (my case with Crossplane) the value is not correct and the server cannot contact guacd service